### PR TITLE
Don't close the aiohttp session unless the motionEye client itself creates it

### DIFF
--- a/motioneye_client/client.py
+++ b/motioneye_client/client.py
@@ -69,7 +69,12 @@ class MotionEyeClient:
             )
 
         self._url = url
-        self._session = session or aiohttp.ClientSession()
+        if session:
+            self._session = session
+            self._created_session = False
+        else:
+            self._session = aiohttp.ClientSession()
+            self._created_session = True
         self._admin_username = admin_username or DEFAULT_ADMIN_USERNAME
         self._admin_password = admin_password or ""
         self._surveillance_username = (
@@ -181,8 +186,9 @@ class MotionEyeClient:
         return await self._async_request("/login")
 
     async def async_client_close(self) -> bool:
-        """Disconnect to the MotionEye server."""
-        await self._session.close()
+        """Disconnect from the MotionEye server."""
+        if self._created_session:
+            await self._session.close()
         return True
 
     async def async_get_manifest(self) -> dict[str, Any] | None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -436,3 +436,12 @@ async def test_is_file_type_movie() -> None:
     assert not client.is_file_type_movie(7)
     assert client.is_file_type_movie(8)
     assert client.is_file_type_movie(100)
+
+
+async def test_session_passed_in_is_not_closed() -> None:
+    """Test a session passed in is not closed."""
+
+    session = Mock()
+    client = MotionEyeClient("http://localhost", session=session)
+    await client.async_client_close()
+    assert not session.close.called


### PR DESCRIPTION
Only close a clientsession if the motionEye client created, otherwise leave it alone.  See: https://github.com/home-assistant/core/issues/53500#issuecomment-886678744