### PR TITLE
GitHub Actions: Add Python 3.10 to build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
     name: Pre-commit
     steps:
       - name: Check out the repository
@@ -46,7 +46,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
     name: Run tests
     steps:
       - name: Check out code from GitHub


### PR DESCRIPTION
In YAML, "3.10" MUST be quoted… https://dev.to/hugovk/the-python-3-1-problem-85g

My sense is that dependency https://pypi.org/project/pytest must be upgraded for Python 3.10.
* https://stackoverflow.com/questions/69528842/an-error-while-trying-to-execute-tests-on-python-3-10-with-pytest